### PR TITLE
Improve contextual robustness

### DIFF
--- a/src/fprime_bootstrap/__main__.py
+++ b/src/fprime_bootstrap/__main__.py
@@ -12,7 +12,7 @@ import os
 import logging
 import argparse
 
-from fprime_bootstrap.bootstrap_project import BootstrapProjectError
+from fprime_bootstrap.bootstrap_project import bootstrap_project, BootstrapProjectError
 
 logging.basicConfig(
     format="[%(levelname)s] %(message)s",
@@ -49,9 +49,7 @@ def main():
 
     try:
         if args.command == "project":
-            from fprime_bootstrap import bootstrap_project
-
-            return bootstrap_project.bootstrap_project(args)
+            return bootstrap_project(args)
 
     except BootstrapProjectError as e:
         LOGGER.error(e)

--- a/src/fprime_bootstrap/__main__.py
+++ b/src/fprime_bootstrap/__main__.py
@@ -12,6 +12,8 @@ import os
 import logging
 import argparse
 
+from fprime_bootstrap import BootstrapProjectError
+
 logging.basicConfig(
     format="[%(levelname)s] %(message)s",
     level=logging.INFO,
@@ -40,10 +42,15 @@ def main():
 
     args = parser.parse_args()
 
-    if args.command == "project":
-        from fprime_bootstrap import bootstrap_project
+    try:
+        if args.command == "project":
+            from fprime_bootstrap import bootstrap_project
 
-        return bootstrap_project.bootstrap_project(args)
+            return bootstrap_project.bootstrap_project(args)
+
+    except BootstrapProjectError as e:
+        LOGGER.error(e)
+        return 1
 
     LOGGER.error("No sub-command supplied")
     parser.print_help()

--- a/src/fprime_bootstrap/__main__.py
+++ b/src/fprime_bootstrap/__main__.py
@@ -39,6 +39,11 @@ def main():
         help="Do not create a virtual environment in the project",
         default=False,
     )
+    project_parser.add_argument(
+        "--tag",
+        type=str,
+        help="Version of F´ to checkout (default: latest release)",
+    )
 
     args = parser.parse_args()
 

--- a/src/fprime_bootstrap/__main__.py
+++ b/src/fprime_bootstrap/__main__.py
@@ -12,7 +12,7 @@ import os
 import logging
 import argparse
 
-from fprime_bootstrap import BootstrapProjectError
+from fprime_bootstrap.bootstrap_project import BootstrapProjectError
 
 logging.basicConfig(
     format="[%(levelname)s] %(message)s",

--- a/src/fprime_bootstrap/bootstrap_project.py
+++ b/src/fprime_bootstrap/bootstrap_project.py
@@ -130,6 +130,9 @@ def run_context_checks(project_path: Path):
             f"Special characters such as single or double quotes and spaces are not allowed in the project path: {real_path}."
         )
 
+    # TODO:
+    # 1) Ideally we would check that the path is not a symlink here, but it doesn't seem to be doable in Python... ?
+    # 2) Elegant way of dealing with line endings in Windows (see https://github.com/nasa/fprime/issues/2566)
     return 0
 
 
@@ -237,34 +240,6 @@ def generate_boilerplate_project(project_path: Path, project_name: str):
             file.rename(file.parent / file.name.replace("-template", ""))
 
 
-def print_success_message(project_name: str):
-    """Prints a success message"""
-    print(
-        f"""
-################################################################
-
-Congratulations! You have successfully created a new F´ project.
-
-A git repository has been initialized and F´ has been added as a
-submodule, you can now create your first commit.
-
-Get started with your F´ project:
-
--- Remember to always activate the virtual environment --
-cd {project_name}
-. fprime-venv/bin/activate
-
--- Create a new component --
-fprime-util new --component
-
--- Create a new deployment --
-fprime-util new --deployment
-
-################################################################
-"""
-    )
-
-
 def get_latest_fprime_release() -> str:
     """Retrieves the latest F´ release from GitHub
 
@@ -302,6 +277,34 @@ def get_latest_fprime_release() -> str:
             return tuple(map(int, version.lstrip("v").split(".")))
 
         return max(tags, key=version_tuple)
+
+
+def print_success_message(project_name: str):
+    """Prints a success message"""
+    print(
+        f"""
+################################################################
+
+Congratulations! You have successfully created a new F´ project.
+
+A git repository has been initialized and F´ has been added as a
+submodule, you can now create your first commit.
+
+Get started with your F´ project:
+
+-- Remember to always activate the virtual environment --
+cd {project_name}
+. fprime-venv/bin/activate
+
+-- Create a new component --
+fprime-util new --component
+
+-- Create a new deployment --
+fprime-util new --deployment
+
+################################################################
+"""
+    )
 
 
 #################### Exceptions ####################

--- a/src/fprime_bootstrap/bootstrap_project.py
+++ b/src/fprime_bootstrap/bootstrap_project.py
@@ -137,7 +137,7 @@ def setup_git_repo(project_path: Path):
         with urlopen("https://api.github.com/repos/nasa/fprime/releases/latest") as url:
             fprime_latest_release = json.loads(url.read().decode())
             latest_tag_name = fprime_latest_release["tag_name"]
-    except HTTPError as e:
+    except HTTPError:
         LOGGER.warning("Unable to retrieve latest F´ release through the GitHub API.")
         if os.getenv("FPRIME_RELEASE_TAG"):
             LOGGER.info(f"Using F´ release tag from FPRIME_RELEASE_TAG environment variable: {os.getenv('FPRIME_RELEASE_TAG')}")
@@ -145,6 +145,7 @@ def setup_git_repo(project_path: Path):
         else:
             tags = subprocess.Popen(["git", "ls-remote", "--tags", "--refs", "https://github.com/nasa/fprime"], stdout=subprocess.PIPE).stdout.readlines()
             latest_tag_name = tags[-1].decode().split("\t")[1].split("/")[-1].strip()
+            LOGGER.warning(f"Attempting to read latest tag with `git ls-remote`. Found tag: {latest_tag_name}.")
 
     # Initialize git repository
     subprocess.run(["git", "init"], cwd=project_path)

--- a/src/fprime_bootstrap/bootstrap_project.py
+++ b/src/fprime_bootstrap/bootstrap_project.py
@@ -127,7 +127,7 @@ def run_context_checks(project_path: Path):
     # Check that no ' " and spaces are in the path and its parents
     if any(char in str(real_path.name) for char in ['"', "'", "´", " "]):
         raise InvalidProjectName(
-            f"Special characters such as ' \" and spaces are not allowed in the project path: {real_path}."
+            f"Special characters such as single or double quotes and spaces are not allowed in the project path: {real_path}."
         )
 
     return 0

--- a/src/fprime_bootstrap/bootstrap_project.py
+++ b/src/fprime_bootstrap/bootstrap_project.py
@@ -11,7 +11,6 @@ import shutil
 import logging
 import subprocess
 import sys
-import os
 from urllib.request import urlopen
 from urllib.error import HTTPError
 from pathlib import Path


### PR DESCRIPTION
Fixes https://github.com/nasa/fprime/issues/2570

Improve robustness for the following cases:
- if GitHub API is not responsive (e.g. rate limit exceeded etc...), resort back to using `git ls-remote` and process the output text. GitHub API is a more robust solution and is therefore kept in for cases where it's available. If things go really bad, `--tag` option has been added to override. 
- Error out if running from Windows (outside of WSL)
- Error out if parent path has quotes, spaces etc... as underlying tools do not manage that well

Also improved the error handling patterns in case someone ever wants to use this package as a library