### PR TITLE
Add `clone` command for existing projects

### DIFF
--- a/src/fprime_bootstrap/__main__.py
+++ b/src/fprime_bootstrap/__main__.py
@@ -47,7 +47,9 @@ def main():
         help="Version of F´ to checkout (default: latest release)",
     )
 
-    clone_parser = subparsers.add_parser("clone", help="Clone an existing remote F´ project")
+    clone_parser = subparsers.add_parser(
+        "clone", help="Clone an existing remote F´ project"
+    )
     clone_parser.add_argument(
         dest="url",
         type=str,

--- a/src/fprime_bootstrap/__main__.py
+++ b/src/fprime_bootstrap/__main__.py
@@ -12,7 +12,9 @@ import os
 import logging
 import argparse
 
-from fprime_bootstrap.bootstrap_project import bootstrap_project, BootstrapProjectError
+from fprime_bootstrap.bootstrap_project import bootstrap_project
+from fprime_bootstrap.clone_project import clone_project
+from fprime_bootstrap.common import BootstrapError
 
 logging.basicConfig(
     format="[%(levelname)s] %(message)s",
@@ -45,13 +47,46 @@ def main():
         help="Version of F´ to checkout (default: latest release)",
     )
 
+    clone_parser = subparsers.add_parser("clone", help="Clone an existing remote F´ project")
+    clone_parser.add_argument(
+        dest="url",
+        type=str,
+        help="URL of the remote repository to clone",
+    )
+    clone_parser.add_argument(
+        "--path",
+        type=str,
+        help="Path to create the project in (default: current directory)",
+        default=os.getcwd(),
+    )
+    clone_parser.add_argument(
+        "--no-venv",
+        action="store_true",
+        help="Do not create a virtual environment in the project",
+        default=False,
+    )
+    clone_parser.add_argument(
+        "--fprime-subpath",
+        type=str,
+        help="Relative path from root of project to F´ submodule (default: ./fprime)",
+        default="./fprime",
+    )
+    clone_parser.add_argument(
+        "--rename",
+        type=str,
+        help="Name of the local project directory (default: remote repository name)",
+        default=os.getcwd(),
+    )
     args = parser.parse_args()
 
     try:
         if args.command == "project":
             return bootstrap_project(args)
 
-    except BootstrapProjectError as e:
+        if args.command == "clone":
+            return clone_project(args)
+
+    except BootstrapError as e:
         LOGGER.error(e)
         return 1
 

--- a/src/fprime_bootstrap/__main__.py
+++ b/src/fprime_bootstrap/__main__.py
@@ -12,7 +12,7 @@ import os
 import logging
 import argparse
 
-from fprime_bootstrap.bootstrap_project import BootstrapProjectError
+from fprime_bootstrap.bootstrap_project import bootstrap_project, BootstrapProjectError
 
 logging.basicConfig(
     format="[%(levelname)s] %(message)s",
@@ -49,9 +49,7 @@ def main():
 
     try:
         if args.command == "project":
-            from fprime_bootstrap import bootstrap_project
-
-            return bootstrap_project.bootstrap_project(args)
+            return bootstrap_project(args)
 
     except BootstrapProjectError as e:
         LOGGER.error(e)

--- a/src/fprime_bootstrap/__main__.py
+++ b/src/fprime_bootstrap/__main__.py
@@ -77,7 +77,6 @@ def main():
         "--rename",
         type=str,
         help="Name of the local project directory (default: remote repository name)",
-        default=os.getcwd(),
     )
     args = parser.parse_args()
 

--- a/src/fprime_bootstrap/__main__.py
+++ b/src/fprime_bootstrap/__main__.py
@@ -12,6 +12,8 @@ import os
 import logging
 import argparse
 
+from fprime_bootstrap import BootstrapProjectError
+
 logging.basicConfig(
     format="[%(levelname)s] %(message)s",
     level=logging.INFO,
@@ -40,10 +42,15 @@ def main():
 
     args = parser.parse_args()
 
-    if args.command == "project":
-        from fprime_bootstrap import bootstrap_project
+    try:
+        if args.command == "project":
+            from fprime_bootstrap import bootstrap_project
 
-        return bootstrap_project.bootstrap_project(args)
+            return bootstrap_project.bootstrap_project(args)
+
+    except BootstrapProjectError as e:
+        LOGGER.error(e)
+        return 1
 
     LOGGER.error("No sub-command supplied")
     parser.print_help()

--- a/src/fprime_bootstrap/__main__.py
+++ b/src/fprime_bootstrap/__main__.py
@@ -39,6 +39,11 @@ def main():
         help="Do not create a virtual environment in the project",
         default=False,
     )
+    project_parser.add_argument(
+        "--tag",
+        type=str,
+        help="Version of F´ to checkout (default: latest release)",
+    )
 
     args = parser.parse_args()
 

--- a/src/fprime_bootstrap/__main__.py
+++ b/src/fprime_bootstrap/__main__.py
@@ -12,7 +12,7 @@ import os
 import logging
 import argparse
 
-from fprime_bootstrap import BootstrapProjectError
+from fprime_bootstrap.bootstrap_project import BootstrapProjectError
 
 logging.basicConfig(
     format="[%(levelname)s] %(message)s",

--- a/src/fprime_bootstrap/__main__.py
+++ b/src/fprime_bootstrap/__main__.py
@@ -68,12 +68,6 @@ def main():
         default=False,
     )
     clone_parser.add_argument(
-        "--fprime-subpath",
-        type=str,
-        help="Relative path from root of project to F´ submodule (default: ./fprime)",
-        default="./fprime",
-    )
-    clone_parser.add_argument(
         "--rename",
         type=str,
         help="Name of the local project directory (default: remote repository name)",

--- a/src/fprime_bootstrap/bootstrap_project.py
+++ b/src/fprime_bootstrap/bootstrap_project.py
@@ -130,6 +130,9 @@ def run_context_checks(project_path: Path):
             f"Special characters such as single or double quotes and spaces are not allowed in the project path: {real_path}."
         )
 
+    # TODO:
+    # 1) Ideally we would check that the path is not a symlink here, but it doesn't seem to be doable in Python... ?
+    # 2) Elegant way of dealing with line endings in Windows (see https://github.com/nasa/fprime/issues/2566)
     return 0
 
 
@@ -237,34 +240,6 @@ def generate_boilerplate_project(project_path: Path, project_name: str):
             file.rename(file.parent / file.name.replace("-template", ""))
 
 
-def print_success_message(project_name: str):
-    """Prints a success message"""
-    print(
-        f"""
-################################################################
-
-Congratulations! You have successfully created a new F´ project.
-
-A git repository has been initialized and F´ has been added as a
-submodule, you can now create your first commit.
-
-Get started with your F´ project:
-
--- Remember to always activate the virtual environment --
-cd {project_name}
-. fprime-venv/bin/activate
-
--- Create a new component --
-fprime-util new --component
-
--- Create a new deployment --
-fprime-util new --deployment
-
-################################################################
-"""
-    )
-
-
 def get_latest_fprime_release() -> str:
     """Retrieves the latest F´ release from GitHub
 
@@ -302,6 +277,34 @@ def get_latest_fprime_release() -> str:
             return tuple(map(int, version.lstrip("v").split(".")))
 
         return max(tags, key=version_tuple)
+
+
+def print_success_message(project_name: str):
+    """Prints a success message"""
+    print(
+        f"""
+################################################################
+
+Congratulations! You have successfully created a new F´ project.
+
+A git repository has been initialized and F´ has been added as a
+submodule, you can now create your first commit.
+
+Get started with your F´ project:
+
+-- Remember to always activate the virtual environment --
+cd {project_name}
+. fprime-venv/bin/activate
+
+-- Create a new component --
+fprime-util new --component
+
+-- Create a new deployment --
+fprime-util new --deployment
+
+################################################################
+"""
+    )
 
 
 #################### Exceptions ####################

--- a/src/fprime_bootstrap/bootstrap_project.py
+++ b/src/fprime_bootstrap/bootstrap_project.py
@@ -137,7 +137,7 @@ def setup_git_repo(project_path: Path):
         with urlopen("https://api.github.com/repos/nasa/fprime/releases/latest") as url:
             fprime_latest_release = json.loads(url.read().decode())
             latest_tag_name = fprime_latest_release["tag_name"]
-    except HTTPError as e:
+    except HTTPError:
         LOGGER.warning("Unable to retrieve latest F´ release through the GitHub API.")
         if os.getenv("FPRIME_RELEASE_TAG"):
             LOGGER.info(f"Using F´ release tag from FPRIME_RELEASE_TAG environment variable: {os.getenv('FPRIME_RELEASE_TAG')}")
@@ -145,6 +145,7 @@ def setup_git_repo(project_path: Path):
         else:
             tags = subprocess.Popen(["git", "ls-remote", "--tags", "--refs", "https://github.com/nasa/fprime"], stdout=subprocess.PIPE).stdout.readlines()
             latest_tag_name = tags[-1].decode().split("\t")[1].split("/")[-1].strip()
+            LOGGER.warning(f"Attempting to read latest tag with `git ls-remote`. Found tag: {latest_tag_name}.")
 
     # Initialize git repository
     subprocess.run(["git", "init"], cwd=project_path)

--- a/src/fprime_bootstrap/bootstrap_project.py
+++ b/src/fprime_bootstrap/bootstrap_project.py
@@ -127,7 +127,7 @@ def run_context_checks(project_path: Path):
     # Check that no ' " and spaces are in the path and its parents
     if any(char in str(real_path.name) for char in ['"', "'", "´", " "]):
         raise InvalidProjectName(
-            f"Special characters such as ' \" and spaces are not allowed in the project path: {real_path}."
+            f"Special characters such as single or double quotes and spaces are not allowed in the project path: {real_path}."
         )
 
     return 0

--- a/src/fprime_bootstrap/bootstrap_project.py
+++ b/src/fprime_bootstrap/bootstrap_project.py
@@ -11,7 +11,6 @@ import shutil
 import logging
 import subprocess
 import sys
-import os
 from urllib.request import urlopen
 from urllib.error import HTTPError
 from pathlib import Path

--- a/src/fprime_bootstrap/clone_project.py
+++ b/src/fprime_bootstrap/clone_project.py
@@ -1,0 +1,80 @@
+"""
+fprime_bootstrap.bootstrap_project:
+
+Bootstraps a new project using cookiecuter
+
+@author thomas-bc
+"""
+
+import logging
+import subprocess
+from pathlib import Path
+from fprime_bootstrap.common import run_system_checks, setup_venv, print_success_message, OutDirectoryError, GitCloneError
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import argparse
+
+
+LOGGER = logging.getLogger("fprime_bootstrap")
+
+
+def clone_project(parsed_args: "argparse.Namespace"):
+    """Creates a new F´ project"""
+
+    # Runs system checks such as Python version, OS requirements etc...
+    run_system_checks()
+
+    target_dir = Path(parsed_args.path)
+
+    try:
+        project_path = clone_git_repo(target_dir, parsed_args.url, parsed_args.rename)
+        if not parsed_args.no_venv:
+            setup_venv(project_path, parsed_args.fprime_subpath)
+
+        print_success_message(project_path)
+
+    except (PermissionError, FileExistsError) as out_directory_error:
+        raise OutDirectoryError(
+            f"{out_directory_error}. Please select a different project name or remove the existing directory."
+        )
+    except FileNotFoundError as e:
+        raise OutDirectoryError(
+            f"{e}. Permission denied to write to the directory.",
+        )
+    return 0
+
+
+def clone_git_repo(target_dir: Path, remote_url: str, new_name: str = None) -> Path:
+    """Clone an F´ project using git. Uses new_name if provided for local project name"""
+
+    if new_name:
+        target_name = new_name
+    else:
+        # Extract the repository name from the remote_url
+        target_name = remote_url.split("/")[-1]
+        # Remove .git extension if present and patiently wait for Python3.9 for str.removesuffix()
+        if target_name.endswith(".git"):
+            target_name = target_name[:-4]
+    
+    # Add F´ as a submodule
+    LOGGER.info(f"Cloning out F´ project in {target_dir} ...")
+    run = subprocess.run(
+        [
+            "git",
+            "clone",
+            "--recurse-submodules",
+            "--shallow-submodules",
+            remote_url,
+            target_name,
+        ],
+        cwd=target_dir,
+    )
+
+    if run.returncode != 0:
+        raise GitCloneError(f"Failed to clone repository: {remote_url}")
+
+    return target_dir / target_name
+
+

--- a/src/fprime_bootstrap/clone_project.py
+++ b/src/fprime_bootstrap/clone_project.py
@@ -9,7 +9,13 @@ Bootstraps a new project using cookiecuter
 import logging
 import subprocess
 from pathlib import Path
-from fprime_bootstrap.common import run_system_checks, setup_venv, print_success_message, OutDirectoryError, GitCloneError
+from fprime_bootstrap.common import (
+    run_system_checks,
+    setup_venv,
+    print_success_message,
+    OutDirectoryError,
+    GitCloneError,
+)
 
 from typing import TYPE_CHECKING
 
@@ -57,7 +63,7 @@ def clone_git_repo(target_dir: Path, remote_url: str, new_name: str = None) -> P
         # Remove .git extension if present and patiently wait for Python3.9 for str.removesuffix()
         if target_name.endswith(".git"):
             target_name = target_name[:-4]
-    
+
     # Add F´ as a submodule
     LOGGER.info(f"Cloning out F´ project in {target_dir} ...")
     run = subprocess.run(
@@ -76,5 +82,3 @@ def clone_git_repo(target_dir: Path, remote_url: str, new_name: str = None) -> P
         raise GitCloneError(f"Failed to clone repository: {remote_url}")
 
     return target_dir / target_name
-
-

--- a/src/fprime_bootstrap/clone_project.py
+++ b/src/fprime_bootstrap/clone_project.py
@@ -6,6 +6,7 @@ Bootstraps a new project using cookiecuter
 @author thomas-bc
 """
 
+import configparser
 import logging
 import subprocess
 from pathlib import Path
@@ -35,9 +36,11 @@ def clone_project(parsed_args: "argparse.Namespace"):
     target_dir = Path(parsed_args.path)
 
     try:
-        project_path = clone_git_repo(target_dir, parsed_args.url, parsed_args.rename)
+        project_path, fprime_path = clone_git_repo(
+            target_dir, parsed_args.url, parsed_args.rename
+        )
         if not parsed_args.no_venv:
-            setup_venv(project_path, parsed_args.fprime_subpath)
+            setup_venv(project_path, fprime_path)
 
         print_success_message(project_path)
 
@@ -52,14 +55,18 @@ def clone_project(parsed_args: "argparse.Namespace"):
     return 0
 
 
-def clone_git_repo(target_dir: Path, remote_url: str, new_name: str = None) -> Path:
-    """Clone an F´ project using git. Uses new_name if provided for local project name"""
+def clone_git_repo(
+    target_dir: Path, remote_url: str, new_name: str = None
+) -> tuple[Path, Path]:
+    """Clone an F´ project using git. Uses new_name if provided for local project name
+    Returns the path to the project and the path to the F´ submodule within the project
+    """
 
     if new_name:
         target_name = new_name
     else:
         # Extract the repository name from the remote_url
-        target_name = remote_url.split("/")[-1]
+        target_name = remote_url.rstrip("/").split("/")[-1]
         # Remove .git extension if present and patiently wait for Python3.9 for str.removesuffix()
         if target_name.endswith(".git"):
             target_name = target_name[:-4]
@@ -81,4 +88,33 @@ def clone_git_repo(target_dir: Path, remote_url: str, new_name: str = None) -> P
     if run.returncode != 0:
         raise GitCloneError(f"Failed to clone repository: {remote_url}")
 
-    return target_dir / target_name
+    project_path = target_dir / target_name
+    fprime_path = find_fprime_path(project_path)
+
+    return project_path, fprime_path
+
+
+def find_fprime_path(project_path: Path) -> Path:
+    """Find the path to the F´ submodule within the project"""
+
+    settings_ini_file = project_path / "settings.ini"
+
+    if not settings_ini_file.exists():
+        raise FileNotFoundError(
+            "settings.ini not found in project - project not correctly formed"
+        )
+
+    settings_ini = configparser.ConfigParser()
+    settings_ini.read(settings_ini_file)
+
+    if "fprime" not in settings_ini:
+        raise KeyError(
+            "fprime section not found in settings.ini - project not correctly formed"
+        )
+
+    if "framework_path" not in settings_ini["fprime"]:
+        raise KeyError(
+            "framework_path not found in fprime section of settings.ini - project not correctly formed"
+        )
+
+    return settings_ini["fprime"]["framework_path"]

--- a/src/fprime_bootstrap/common.py
+++ b/src/fprime_bootstrap/common.py
@@ -1,0 +1,122 @@
+import sys
+import shutil
+import subprocess
+from pathlib import Path
+import logging
+
+LOGGER = logging.getLogger("fprime_bootstrap")
+
+
+def run_system_checks():
+    """Runs system checks"""
+    # Check Python version
+    if sys.version_info < (3, 8):
+        raise UnsupportedPythonVersion(
+            "Python 3.8 or higher is required to use the F´ Python tooling suite. "
+            "Please install Python 3.8 or higher and try again."
+        )
+
+    # Check if Git is installed and available - needed for cloning F´ as submodule
+    if not shutil.which("git"):
+        raise GitNotInstalled(
+            "Git is not installed or in PATH. Please install Git and try again."
+        )
+
+    # Check if running on Windows
+    if sys.platform == "win32":
+        raise UnsupportedPlatform(
+            "F´ does not currently support Windows. Please use WSL (https://learn.microsoft.com/en-us/windows/wsl/about), "
+            "or a Linux or macOS system. If you are using WSL, please ensure you are running this script from WSL."
+        )
+    return 0
+
+
+def setup_venv(project_path: Path, fprime_subpath: Path = Path("fprime")):
+    """Sets up a new virtual environment"""
+    venv_path = project_path / "fprime-venv"
+
+    LOGGER.info(f"Creating virtual environment in {venv_path} ...")
+    subprocess.run([Path(sys.executable), "-m", "venv", venv_path])
+
+    # Find pip
+    pip = None
+    if (venv_path / "bin/pip").exists():
+        pip = venv_path / "bin/pip"
+    elif (venv_path / "bin/pip3").exists():
+        pip = venv_path / "bin/pip3"
+    else:
+        raise FileNotFoundError("Could not find pip executable in venv.")
+
+    LOGGER.info("Upgrading pip...")
+    subprocess.run([pip, "install", "--upgrade", "pip"])
+
+    LOGGER.info("Installing F´ dependencies...")
+    subprocess.run(
+        [
+            pip,
+            "install",
+            "-Ur",
+            project_path / fprime_subpath / "requirements.txt",
+        ]
+    )
+
+
+def print_success_message(project_name: str):
+    """Prints a success message"""
+    print(
+        f"""
+################################################################
+
+Congratulations! You have successfully created a new F´ project.
+
+A git repository has been initialized and F´ has been added as a
+submodule, you can now create your first commit.
+
+Get started with your F´ project:
+
+-- Remember to always activate the virtual environment --
+cd {project_name}
+. fprime-venv/bin/activate
+
+-- Create a new component --
+fprime-util new --component
+
+-- Create a new deployment --
+fprime-util new --deployment
+
+################################################################
+"""
+    )
+
+
+#################### Exceptions ####################
+
+
+class BootstrapError(Exception):
+    pass
+
+
+class BootstrapProjectError(BootstrapError):
+    pass
+
+
+class UnsupportedPythonVersion(BootstrapProjectError):
+    pass
+
+
+class GitNotInstalled(BootstrapProjectError):
+    pass
+
+class GitCloneError(BootstrapProjectError):
+    pass
+
+class UnsupportedPlatform(BootstrapProjectError):
+    pass
+
+
+class InvalidProjectName(BootstrapProjectError):
+    pass
+
+
+class OutDirectoryError(BootstrapProjectError):
+    pass

--- a/src/fprime_bootstrap/common.py
+++ b/src/fprime_bootstrap/common.py
@@ -107,8 +107,10 @@ class UnsupportedPythonVersion(BootstrapProjectError):
 class GitNotInstalled(BootstrapProjectError):
     pass
 
+
 class GitCloneError(BootstrapProjectError):
     pass
+
 
 class UnsupportedPlatform(BootstrapProjectError):
     pass


### PR DESCRIPTION
Addresses [nasa/fprime#2251](https://github.com/nasa/fprime/issues/2251)

Allows stuff like:
```
fprime-bootstrap clone https://github.com/fprime-community/fprime-workshop-led-blinker
```
```
fprime-bootstrap clone --rename led-blinker --no-venv https://github.com/fprime-community/fprime-workshop-led-blinker.git
```

```
fprime-bootstrap clone --path ./other/path https://github.com/fprime-community/fprime-workshop-led-blinker
```

Also works with old in-tree project structure like such:
```
fprime-bootstrap clone --fprime-subpath ./ https://github.com/nasa/fprime
```