### PR TITLE
F Prime lib structure

### DIFF
--- a/src/fprime_bootstrap/bootstrap_project.py
+++ b/src/fprime_bootstrap/bootstrap_project.py
@@ -130,6 +130,8 @@ def setup_git_repo(project_path: Path, tag: str):
     else:
         tag_name = get_latest_fprime_release()
 
+    library_path = project_path / "lib"
+
     # Add F´ as a submodule
     LOGGER.info(f"Checking out F´ submodule at version: {tag_name}")
     subprocess.run(
@@ -141,7 +143,7 @@ def setup_git_repo(project_path: Path, tag: str):
             "1",
             "https://github.com/nasa/fprime.git",
         ],
-        cwd=project_path,
+        cwd=library_path,
     )
     # Checkout F´ submodules (e.g. googletest)
     res = subprocess.run(
@@ -154,7 +156,7 @@ def setup_git_repo(project_path: Path, tag: str):
             "[WARNING] Unable to initialize submodules. Functionality may be limited."
         )
 
-    fprime_path = project_path / "fprime"
+    fprime_path = library_path / "fprime"
 
     subprocess.run(
         ["git", "fetch", "origin", "--depth", "1", "tag", tag_name],

--- a/src/fprime_bootstrap/common.py
+++ b/src/fprime_bootstrap/common.py
@@ -31,7 +31,7 @@ def run_system_checks():
     return 0
 
 
-def setup_venv(project_path: Path, fprime_subpath: Path = Path("fprime")):
+def setup_venv(project_path: Path, fprime_subpath: Path = Path("lib/fprime")):
     """Sets up a new virtual environment"""
     venv_path = project_path / "fprime-venv"
 

--- a/src/fprime_bootstrap/templates/fprime-project-template/CMakeLists.txt-template
+++ b/src/fprime_bootstrap/templates/fprime-project-template/CMakeLists.txt-template
@@ -10,7 +10,7 @@ project({{FPRIME_PROJECT_NAME}} C CXX)
 # F' Core Setup
 # This includes all of the F prime core components, and imports the make-system.
 ###
-include("${CMAKE_CURRENT_LIST_DIR}/fprime/cmake/FPrime.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/lib/fprime/cmake/FPrime.cmake")
 # NOTE: register custom targets between these two lines
 fprime_setup_included_code()
 

--- a/src/fprime_bootstrap/templates/fprime-project-template/lib/README.md
+++ b/src/fprime_bootstrap/templates/fprime-project-template/lib/README.md
@@ -1,0 +1,3 @@
+# Libraries
+
+Libraries used by F Prime should live here.

--- a/src/fprime_bootstrap/templates/fprime-project-template/settings.ini
+++ b/src/fprime_bootstrap/templates/fprime-project-template/settings.ini
@@ -1,6 +1,6 @@
 [fprime]
 project_root: .
-framework_path: ./fprime
+framework_path: ./lib/fprime
 
 default_cmake_options:  FPRIME_ENABLE_FRAMEWORK_UTS=OFF
                         FPRIME_ENABLE_AUTOCODER_UTS=OFF


### PR DESCRIPTION
Making `fprime-bootstrap project` create the `lib` file structure with `fprime` inside of it. This aligns with the standard file structure we plan to have for future projects.