### PR TITLE
Adds a --populate flag

### DIFF
--- a/src/fprime_bootstrap/__main__.py
+++ b/src/fprime_bootstrap/__main__.py
@@ -46,6 +46,12 @@ def main():
         type=str,
         help="Version of F´ to checkout (default: latest release)",
     )
+    project_parser.add_argument(
+        "--populate",
+        action="store_true",
+        default=False,
+        help="Populate an existing direcory with a new F´ project (default: False)",
+    )
 
     clone_parser = subparsers.add_parser(
         "clone", help="Clone an existing remote F´ project"

--- a/src/fprime_bootstrap/bootstrap_project.py
+++ b/src/fprime_bootstrap/bootstrap_project.py
@@ -46,13 +46,13 @@ def bootstrap_project(parsed_args: "argparse.Namespace"):
     # Ask user for project name
     project_name = (
         input(f"Project name ({DEFAULT_PROJECT_NAME}): ") or DEFAULT_PROJECT_NAME
-    )
+    ) if not parsed_args.populate else target_dir.name
     check_project_name(project_name)
 
-    project_path = target_dir / project_name
+    project_path = target_dir / project_name if not parsed_args.populate else target_dir
 
     try:
-        generate_boilerplate_project(project_path, project_name)
+        generate_boilerplate_project(project_path, project_name, populate=parsed_args.populate)
         setup_git_repo(project_path, parsed_args.tag)
         if not parsed_args.no_venv:
             setup_venv(project_path)
@@ -178,11 +178,11 @@ def setup_git_repo(project_path: Path, tag: str):
         sys.exit(1)
 
 
-def generate_boilerplate_project(project_path: Path, project_name: str):
+def generate_boilerplate_project(project_path: Path, project_name: str, populate: bool = False):
     """Generates a new project"""
     source = Path(__file__).parent / "templates/fprime-project-template"
     # copy files from template into target path
-    shutil.copytree(source, project_path)
+    shutil.copytree(source, project_path, dirs_exist_ok=populate)
 
     # Iterate over all template files and replace {{FPRIME_PROJECT_NAME}} placeholder with project_name
     for file in project_path.rglob("*-template"):

--- a/src/fprime_bootstrap/bootstrap_project.py
+++ b/src/fprime_bootstrap/bootstrap_project.py
@@ -45,14 +45,18 @@ def bootstrap_project(parsed_args: "argparse.Namespace"):
     target_dir = Path(parsed_args.path)
     # Ask user for project name
     project_name = (
-        input(f"Project name ({DEFAULT_PROJECT_NAME}): ") or DEFAULT_PROJECT_NAME
-    ) if not parsed_args.populate else target_dir.name
+        (input(f"Project name ({DEFAULT_PROJECT_NAME}): ") or DEFAULT_PROJECT_NAME)
+        if not parsed_args.populate
+        else target_dir.name
+    )
     check_project_name(project_name)
 
     project_path = target_dir / project_name if not parsed_args.populate else target_dir
 
     try:
-        generate_boilerplate_project(project_path, project_name, populate=parsed_args.populate)
+        generate_boilerplate_project(
+            project_path, project_name, populate=parsed_args.populate
+        )
         setup_git_repo(project_path, parsed_args.tag)
         if not parsed_args.no_venv:
             setup_venv(project_path)
@@ -178,7 +182,9 @@ def setup_git_repo(project_path: Path, tag: str):
         sys.exit(1)
 
 
-def generate_boilerplate_project(project_path: Path, project_name: str, populate: bool = False):
+def generate_boilerplate_project(
+    project_path: Path, project_name: str, populate: bool = False
+):
     """Generates a new project"""
     source = Path(__file__).parent / "templates/fprime-project-template"
     # copy files from template into target path

--- a/src/fprime_bootstrap/bootstrap_project.py
+++ b/src/fprime_bootstrap/bootstrap_project.py
@@ -130,6 +130,8 @@ def setup_git_repo(project_path: Path, tag: str):
     else:
         tag_name = get_latest_fprime_release()
 
+    library_path = project_path / "lib"
+
     # Add F´ as a submodule
     LOGGER.info(f"Checking out F´ submodule at version: {tag_name}")
     subprocess.run(
@@ -141,7 +143,7 @@ def setup_git_repo(project_path: Path, tag: str):
             "1",
             "https://github.com/nasa/fprime.git",
         ],
-        cwd=project_path,
+        cwd=library_path,
     )
     # Checkout F´ submodules (e.g. googletest)
     res = subprocess.run(
@@ -154,7 +156,7 @@ def setup_git_repo(project_path: Path, tag: str):
             "[WARNING] Unable to initialize submodules. Functionality may be limited."
         )
 
-    fprime_path = project_path / "fprime"
+    fprime_path = library_path / "fprime"
 
     subprocess.run(
         ["git", "fetch", "origin", "--depth", "1", "tag", tag_name],

--- a/src/fprime_bootstrap/common.py
+++ b/src/fprime_bootstrap/common.py
@@ -31,7 +31,7 @@ def run_system_checks():
     return 0
 
 
-def setup_venv(project_path: Path, fprime_subpath: Path = Path("fprime")):
+def setup_venv(project_path: Path, fprime_subpath: Path = Path("lib/fprime")):
     """Sets up a new virtual environment"""
     venv_path = project_path / "fprime-venv"
 

--- a/src/fprime_bootstrap/templates/fprime-project-template/CMakeLists.txt-template
+++ b/src/fprime_bootstrap/templates/fprime-project-template/CMakeLists.txt-template
@@ -10,7 +10,7 @@ project({{FPRIME_PROJECT_NAME}} C CXX)
 # F' Core Setup
 # This includes all of the F prime core components, and imports the make-system.
 ###
-include("${CMAKE_CURRENT_LIST_DIR}/fprime/cmake/FPrime.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/lib/fprime/cmake/FPrime.cmake")
 # NOTE: register custom targets between these two lines
 fprime_setup_included_code()
 

--- a/src/fprime_bootstrap/templates/fprime-project-template/lib/README.md
+++ b/src/fprime_bootstrap/templates/fprime-project-template/lib/README.md
@@ -1,0 +1,3 @@
+# Libraries
+
+Libraries used by F Prime should live here.

--- a/src/fprime_bootstrap/templates/fprime-project-template/settings.ini
+++ b/src/fprime_bootstrap/templates/fprime-project-template/settings.ini
@@ -1,6 +1,6 @@
 [fprime]
 project_root: .
-framework_path: ./fprime
+framework_path: ./lib/fprime
 
 default_cmake_options:  FPRIME_ENABLE_FRAMEWORK_UTS=OFF
                         FPRIME_ENABLE_AUTOCODER_UTS=OFF


### PR DESCRIPTION
One requested workflow is to allow users to create a blank repository via Github and then bootstrap that entity.  This allows that workflow.

```
git clone ....blank repo....
fprime-bootstrap project --path blank-repo --populate
```

Not it depend on PR: #14