### PR TITLE
Fix project namespace when using --populate

### DIFF
--- a/src/fprime_bootstrap/bootstrap_project.py
+++ b/src/fprime_bootstrap/bootstrap_project.py
@@ -58,12 +58,8 @@ def bootstrap_project(parsed_args: "argparse.Namespace"):
     # Ask user for project name
     default_project_name = kebab_to_pascal_case(repo_name)
     project_namespace = (
-        (
-            input(f"Project top-level namespace [{default_project_name}]: ")
-            or default_project_name
-        )
-        if not parsed_args.populate
-        else target_dir.name
+        input(f"Project top-level namespace [{default_project_name}]: ")
+        or default_project_name
     )
     check_project_name(project_namespace)
 


### PR DESCRIPTION
When using `fprime-bootstrap project --populate`, top-level namespace should *not* be the same as `target_dir` which is the repo name. Instead, always ask for user input.