### PR TITLE
Used regex check on project_name in place of .isalnum to fix expected command behavior

### DIFF
--- a/src/fprime_bootstrap/bootstrap_project.py
+++ b/src/fprime_bootstrap/bootstrap_project.py
@@ -11,6 +11,7 @@ import shutil
 import logging
 import subprocess
 import sys
+import re
 from urllib.request import urlopen
 from urllib.error import HTTPError
 from pathlib import Path
@@ -89,7 +90,7 @@ def bootstrap_project(parsed_args: "argparse.Namespace"):
 def check_project_name(project_name: str) -> bool:
     """Checks if a project name is valid. Project name should be a valid
     FPP identifier, it should only contain alphanumeric characters and underscores."""
-    if not project_name.isalnum():
+    if not re.match(r'[A-Za-z0-9_]+$', project_name):
         raise InvalidProjectName(
             f"Invalid project name: {project_name}. "
             "Project name should only contain alphanumeric characters and underscores."

--- a/src/fprime_bootstrap/bootstrap_project.py
+++ b/src/fprime_bootstrap/bootstrap_project.py
@@ -90,10 +90,10 @@ def bootstrap_project(parsed_args: "argparse.Namespace"):
 def check_project_name(project_name: str) -> bool:
     """Checks if a project name is valid. Project name should be a valid
     FPP identifier, it should only contain alphanumeric characters and underscores."""
-    if not re.match(r'[A-Za-z0-9_]+$', project_name):
+    if not re.match(r'^[A-Za-z][A-Za-z0-9_]*$', project_name):
         raise InvalidProjectName(
             f"Invalid project name: {project_name}. "
-            "Project name should only contain alphanumeric characters and underscores."
+            "Project name must start with a letter and only contain alphanumeric characters and underscores."
         )
 
 


### PR DESCRIPTION
| | |
|:---|:---|
|**_Related Issue(s)_**| [Issue #4376](https://github.com/nasa/fprime/issues/4376) |
|**_Has Unit Tests (y/n)_**| N |
|**_Documentation Included (y/n)_**|  N |
|**_Generative AI was used in this contribution (y/n)_**| N |

---
## Change Description

Made patch in regards to [Issue #4376](https://github.com/nasa/fprime/issues/4376)

Project names containing alphanumeric chars and underscores are valid. 

## Rationale

Use of custom regex allows for alignment of expected behavior as indicated by error message upon true invalid project_name input